### PR TITLE
DS-424 Add the Membership Calculator block to Layout Builder

### DIFF
--- a/modules/lb_membership_calculator/config/install/block_content.type.lb_membership_calculator.yml
+++ b/modules/lb_membership_calculator/config/install/block_content.type.lb_membership_calculator.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: lb_membership_calculator
+label: 'Membership Calculator'
+revision: 0
+description: 'A component to add Membership Calculator block to Layout Builder.'

--- a/modules/lb_membership_calculator/config/install/core.entity_form_display.block_content.lb_membership_calculator.default.yml
+++ b/modules/lb_membership_calculator/config/install/core.entity_form_display.block_content.lb_membership_calculator.default.yml
@@ -1,0 +1,35 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.lb_membership_calculator
+    - field.field.block_content.lb_membership_calculator.field_block
+  module:
+    - plugin
+id: block_content.lb_membership_calculator.default
+targetEntityType: block_content
+bundle: lb_membership_calculator
+mode: default
+content:
+  field_block:
+    type: 'plugin_selector:plugin_select_list'
+    weight: 27
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  info:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/lb_membership_calculator/config/install/core.entity_view_display.block_content.lb_membership_calculator.default.yml
+++ b/modules/lb_membership_calculator/config/install/core.entity_view_display.block_content.lb_membership_calculator.default.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.lb_membership_calculator
+    - field.field.block_content.lb_membership_calculator.field_block
+  module:
+    - plugin
+id: block_content.lb_membership_calculator.default
+targetEntityType: block_content
+bundle: lb_membership_calculator
+mode: default
+content:
+  field_block:
+    type: plugin_block_built
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/modules/lb_membership_calculator/config/install/field.field.block_content.lb_membership_calculator.field_block.yml
+++ b/modules/lb_membership_calculator/config/install/field.field.block_content.lb_membership_calculator.field_block.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.lb_membership_calculator
+    - field.storage.block_content.field_block
+  module:
+    - datalayer
+    - plugin
+third_party_settings:
+  datalayer:
+    expose: 0
+    label: field_block
+id: block_content.lb_membership_calculator.field_block
+field_name: field_block
+entity_type: block_content
+bundle: lb_membership_calculator
+label: Block
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    plugin_id: memberships_block
+    plugin_configuration:
+      id: memberships_block
+      label: 'Membership Calculator'
+      label_display: '0'
+      provider: openy_memberships_front
+    plugin_configuration_schema_id: block.settings.memberships_block
+default_value_callback: ''
+settings: {  }
+field_type: 'plugin:block'

--- a/modules/lb_membership_calculator/config/install/field.field.block_content.lb_membership_calculator.field_block.yml
+++ b/modules/lb_membership_calculator/config/install/field.field.block_content.lb_membership_calculator.field_block.yml
@@ -16,7 +16,7 @@ field_name: field_block
 entity_type: block_content
 bundle: lb_membership_calculator
 label: Block
-description: ''
+description: 'A reference to the Memberships Block'
 required: false
 translatable: true
 default_value:

--- a/modules/lb_membership_calculator/config/install/field.storage.block_content.field_block.yml
+++ b/modules/lb_membership_calculator/config/install/field.storage.block_content.field_block.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - plugin
+id: block_content.field_block
+field_name: field_block
+entity_type: block_content
+type: 'plugin:block'
+settings: {  }
+module: plugin
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/lb_membership_calculator/config/install/language.content_settings.block_content.lb_membership_calculator.yml
+++ b/modules/lb_membership_calculator/config/install/language.content_settings.block_content.lb_membership_calculator.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.lb_membership_calculator
+id: block_content.lb_membership_calculator
+target_entity_type_id: block_content
+target_bundle: lb_membership_calculator
+default_langcode: site_default
+language_alterable: false

--- a/modules/lb_membership_calculator/lb_membership_calculator.features.yml
+++ b/modules/lb_membership_calculator/lb_membership_calculator.features.yml
@@ -1,0 +1,1 @@
+required: true

--- a/modules/lb_membership_calculator/lb_membership_calculator.info.yml
+++ b/modules/lb_membership_calculator/lb_membership_calculator.info.yml
@@ -1,0 +1,10 @@
+name: 'LB Membership Calculator'
+type: module
+description: 'Helper module to show "Membership Calculator" block in Layout Builder.'
+core_version_requirement: ^8.8 || ^9 || ^10
+dependencies:
+  - block_content
+  - layout_builder
+  - y_lb
+  - openy_memberships
+version: 1.0.0

--- a/modules/lb_membership_calculator/lb_membership_calculator.info.yml
+++ b/modules/lb_membership_calculator/lb_membership_calculator.info.yml
@@ -3,8 +3,8 @@ type: module
 description: 'Helper module to show "Membership Calculator" block in Layout Builder.'
 core_version_requirement: ^8.8 || ^9 || ^10
 dependencies:
-  - block_content
-  - layout_builder
+  - drupal:block_content
+  - drupal:layout_builder
   - y_lb
   - openy_memberships
 version: 1.0.0

--- a/modules/lb_membership_calculator/lb_membership_calculator.module
+++ b/modules/lb_membership_calculator/lb_membership_calculator.module
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * @file
+ * Contains lb_membership_calculator module hooks.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_theme().
+ */
+function lb_membership_calculator_theme() {
+  return [
+    'block__lb_membership_calculator' => [
+      'base hook' => 'block',
+      'template' => 'block--lb-membership-calculator',
+    ]
+  ];
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function lb_membership_calculator_preprocess_block__lb_membership_calculator(&$variables) {
+  // We need this library to display the Membership Builder block.
+  $variables['#attached']['library'][] = 'openy_memberships/memberships-app';
+  if ($variables['in_preview']) {
+    $variables['in_preview_placeholder'] = t('Memberships Calculator: To see your changes in this block, please save the layout.');
+  }
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function lb_membership_calculator_form_alter(&$form, FormStateInterface $form_state) {
+  // Block configuration form.
+  if (in_array($form['#form_id'],
+    [
+      'layout_builder_add_block',
+      'layout_builder_update_block',
+    ]
+  )) {
+    /** @var \Drupal\layout_builder\Form\ConfigureBlockFormBase $form_object */
+    $form_object = $form_state->getFormObject();
+    $component = $form_object->getCurrentComponent();
+    $plugin = $component->getPlugin();
+    $block_id = $plugin->getDerivativeId() ?? $plugin->getBaseId();
+
+    if ($block_id === 'lb_membership_calculator') {
+      if (isset($form['settings']['block_form'])) {
+        $form['settings']['block_form']['#process'][] = '_inline_block_filed_process';
+      }
+    }
+  }
+}
+
+/**
+ * Custom process callback for inline block elements.
+ *
+ * @param array $element
+ *   Element to process.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ *
+ * @return array
+ *   Processed element.
+ */
+function _inline_block_filed_process(array $element, FormStateInterface $form_state) {
+  if (isset($element['field_block'])) {
+    $element['field_block']['widget']['#after_build'][] = '_after_build_callback';
+  }
+  return $element;
+}
+
+/**
+ * Custom '#after_build' callback for field_block.
+ *
+ * @param array $element
+ *   Element to process.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ *
+ * @return array
+ *   Processed element.
+ */
+function _after_build_callback($element, FormStateInterface $form_state) {
+  if (isset($element[0]['plugin_selector']['container'])) {
+    // Hide the select block field and the custom block's title field.
+    $element[0]['plugin_selector']['container']['select']['container']['#attributes']['class'][] = 'hidden';
+    $element[0]['plugin_selector']['container']['plugin_form']['#attributes']['class'][] = 'hidden';
+  }
+  return $element;
+}

--- a/modules/lb_membership_calculator/templates/block--lb-membership-calculator.html.twig
+++ b/modules/lb_membership_calculator/templates/block--lb-membership-calculator.html.twig
@@ -1,0 +1,48 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - block_content: Block content entity instance with all available fields.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{% set classes = [
+  'block',
+  'block-' ~ configuration.provider|clean_class,
+  'block-' ~ plugin_id|clean_class
+] %}
+
+<div{{ attributes.addClass(classes).setAttribute('id', plugin_id|clean_class ~ configuration['block_revision_id']) }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {% if in_preview %}
+      {{ in_preview_placeholder }}
+    {% else %}
+      {{ content }}
+    {% endif %}
+  {% endblock %}
+</div>


### PR DESCRIPTION
Issue: [DS-424](https://yusa.atlassian.net/browse/DS-424)

The PR provides the ability to add the Membership Calculator block to the LB.

How it looks like:
![DS-424-AddBlock](https://user-images.githubusercontent.com/744406/228307667-fab784c2-8cf4-43dc-ad1d-b1aa3c140e64.png)
![DS-424-ConfigureBlock](https://user-images.githubusercontent.com/744406/228307700-930e060d-a2ae-472f-80d0-e8cfa4c3c208.png)
In LB the Membership app doesn't initial properly after block changes (needs to reload the page), so we use a placeholder instead empty space

![DS-424-LBplaceholder](https://user-images.githubusercontent.com/744406/228307716-5f610ebd-314c-4bc2-8c88-13a5d5eebaf1.png)
On front:

![DS-424-MembershipCalcFront](https://user-images.githubusercontent.com/744406/228307732-3fae08b3-0af8-49e7-aa11-80172dff3f1d.png)

