### PR TITLE
Fix calculator/framework terminology

### DIFF
--- a/modules/lb_membership_framework/lb_membership_framework.module
+++ b/modules/lb_membership_framework/lb_membership_framework.module
@@ -26,7 +26,7 @@ function lb_membership_framework_preprocess_block__lb_membership_framework(&$var
   // We need this library to display the Membership Builder block.
   $variables['#attached']['library'][] = 'openy_memberships/memberships-app';
   if ($variables['in_preview']) {
-    $variables['in_preview_placeholder'] = t('Memberships Calculator: To see your changes in this block, please save the layout.');
+    $variables['in_preview_placeholder'] = t('Membership Framework: To see your changes in this block, please save the layout.');
   }
 }
 


### PR DESCRIPTION
![Edit_layout_for_Test_LB___Drush_Site-Install](https://github.com/YCloudYUSA/yusaopeny_memberships/assets/238201/cee267c8-3507-4c7d-806a-36114b0d79b4)
Fix placeholder text to refer to framework instead of calculator.