### PR TITLE
[DS-1418] Remove call deprecated function render()

### DIFF
--- a/src/Controller/OpenyMemberships.php
+++ b/src/Controller/OpenyMemberships.php
@@ -26,7 +26,6 @@ use Drupal\Core\Url;
  */
 class OpenyMemberships extends ControllerBase {
 
-
   /**
    * The entityTypeManager.
    *
@@ -476,7 +475,7 @@ class OpenyMemberships extends ControllerBase {
               'currency' => $order_item->getTotalPrice()->getCurrencyCode(),
               'field_best_value' => $purchasedEntity->field_best_value->value,
               'product_title' => $product->getTitle(),
-              'product_description' => render($product_description),
+              'product_description' => $this->renderer->render($product_description),
               'product_branch' => $product_branch,
             ];
           }


### PR DESCRIPTION
[DS-1418](https://yusa.atlassian.net/browse/DS-1418)
Fix for issue:
`Error: Call to undefined function Drupal\openy_memberships\Controller\render() in Drupal\openy_memberships\Controller\OpenyMemberships->getSummaryData() (line 479 of /var/www/docroot/modules/contrib/yusaopeny_memberships/src/Controller/OpenyMemberships.php).`
