### PR TITLE
[DS-1418] Update config for the front app to remove DiscountFinder step for Drupal version upper 9

### DIFF
--- a/openy_memberships.install
+++ b/openy_memberships.install
@@ -120,3 +120,10 @@ function openy_memberships_update_8005() {
   $config->set("steps", "BranchSelectorHome\r\nFamily\r\nResults\r\nSummary\r\nJoinNow\r\nSuccess")
     ->save();
 }
+
+/**
+ * Update config for front app to remove DiscountFinder step.
+ */
+function openy_memberships_update_9001() {
+  openy_memberships_update_8005();
+}


### PR DESCRIPTION
For Drupal version upper 9, the hook_update that removed the **DiscountFinder** step wasn't applied. As a result, we got an error message:

`[vue-router] Route with name 'DiscountFinder' does not exist
`
![DS-1418-RouteNotExistpng](https://github.com/YCloudYUSA/yusaopeny_memberships/assets/744406/99d5990d-a427-45a1-92b6-12a3610feac5)

